### PR TITLE
Stablise sysdig driver compilation and vastly reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,33 @@
-FROM alpine:3.1
+FROM alpine:3.4
+ARG SYSDIGVER=0.13.0
 
-RUN apk add  --update wget ca-certificates \
-  git \
-  build-base gcc abuild binutils \
-  cmake 
+RUN apk add --no-cache --update wget ca-certificates \
+    build-base gcc abuild binutils \
+    bc \
+    cmake && \
 
-RUN export KERNELVER=`uname -r  | cut -d '-' -f 1`  && \
-  export KERNELDIR=/linux-$KERNELVER && \
+  export KERNELVER=`uname -r  | cut -d '-' -f 1`  && \
+  export KERNELDIR=/src/linux-$KERNELVER && \
+  mkdir /src && \
+  cd /src && \
   wget https://www.kernel.org/pub/linux/kernel/v4.x/linux-$KERNELVER.tar.gz && \
   tar zxf linux-$KERNELVER.tar.gz && \
-  cd linux-$KERNELVER && \
+  cd /src/linux-$KERNELVER && \
   zcat /proc/1/root/proc/config.gz > .config && \
   make modules_prepare && \
-  mv .config ../config && \
-  cd .. && \
-  git clone https://github.com/draios/sysdig.git && \
-  cd sysdig && \
-  mkdir build && \
-  cd build && \
-  cmake .. && \
-  make driver
-  
+  mv .config /src/config && \
+  cd /src && \
+  wget https://github.com/draios/sysdig/archive/$SYSDIGVER.tar.gz && \
+  tar zxf $SYSDIGVER.tar.gz && \
+  mkdir -p /sysdig/build && \
+  cd /sysdig/build && \
+  cmake /src/sysdig-$SYSDIGVER && \
+  make driver && \
+
+  rm -rf /src && \
+  apk del wget ca-certificates \
+    build-base gcc abuild binutils \
+    bc \
+    cmake
 
 CMD ["insmod","/sysdig/build/driver/sysdig-probe.ko"] 


### PR DESCRIPTION
* Sysdig driver was having trouble compiling on alpine 3.1's gcc 4.8
* Git was downloading the dev branch, switched instead to the latest release version
* Removing all sources and installed packages, along with disabling apk cache reduces the image size from 908MB to 7.36MB